### PR TITLE
fix(date-processor, remove-processor): update linting for date processor and enhance field listing behavior for remove processor 

### DIFF
--- a/date.go
+++ b/date.go
@@ -73,7 +73,8 @@ func (p *DateProc) Render(dst io.Writer) error {
 {{end}}- date:` +
 		preamble + `
     field: {{yaml_string .Field}}
-{{- with .TargetField}}    target_field: {{yaml_string .}}
+{{- with .TargetField}}
+    target_field: {{yaml_string .}}
 {{- end -}}
 {{- with .Formats}}
     formats:{{range .}}

--- a/remove.go
+++ b/remove.go
@@ -58,12 +58,16 @@ func (p *RemoveProc) Render(dst io.Writer) error {
 {{with .Comment}}{{comment .}}
 {{end}}- remove:` +
 		preamble + `
-{{- with .Fields}}
-    field:{{range .}}
+{{- if eq (len .Fields) 1}}
+    field: {{index .Fields 0}}
+{{- else if gt (len .Fields) 1}}
+    field:{{range .Fields}}
       - {{yaml_string .}}{{end}}
 {{- end -}}
-{{- with .Keep}}
-    keep:{{range .}}
+{{- if eq (len .Keep) 1}}
+    keep: {{index .Keep 0}}
+{{- else if gt (len .Keep) 1}}
+    keep:{{range .Keep}}
       - {{yaml_string .}}{{end}}
 {{- end -}}
 {{- with .IgnoreMissing}}


### PR DESCRIPTION
This PR resolves two issues in the date and remove processors:

1. Incorrect YAML linting in the date processor.
2. Field listing in remove processor

### 1. Update the linting of Date Processor

**Issue**

The date processor previously produced invalid YAML formatting specifically, the `target_field` key was incorrectly aligned, causing linting errors when used in ingest pipelines.

**Current behaviour**
```yaml
---
processors:
  - date:
      tag: date_field_b_into_field_a
      field: field_b      target_field: field_a
      formats:
        - formate_1
        - formate_2
```

**Resolution**
This PR fixes the linting by ensuring `target_field` appears on a new line.

**Updated behaviour**
```yaml
---
processors:
  - date:
      tag: date_field_b_into_field_a
      field: field_b
      target_field: field_a
      formats:
        - formate_1
        - formate_2
```

### 2. Enhance Field Listing Behaviour in Remove Processor

**Issue**

When using the remove processor with one or more fields, all fields were always represented as an array.
This caused validation errors when using remove in certain scenario (for example, the `message` field).

**Example code**
```go
REMOVE("message").
  TAG("remove_message").
  IF("ctx.event?.original != null").
  DESCRIPTION("Removes the message field if event.original exists").
  IGNORE_MISSING(true)
```

**Generated output**

```yaml
- remove:
    description: The `message` field is no longer required if the document has an `event.original` field.
    tag: remove_message
    if: ctx.event?.original != null
    field:
      - message
    ignore_missing: true
```

**Error**
Below error generated when linting package with `elastic-package check`.
```
Lint the package
Error: checking package failed: linting package failed: found 1 validation error:
   1. file "/root/integrations/packages/{package_name}/data_stream/{data_stream_name}/elasticsearch/ingest_pipeline/default.yml" is invalid: field processors.1.remove.field: rename "message" to "event.original" processor requires remove "message" processor (JSE00001)
   ```

**Resolution**
Now, if only one field is being removed, it is represented as a string instead of an array.

**Updated output**

```yaml
- remove:
    description: The `message` field is no longer required if the document has an `event.original` field.
    tag: remove_message
    if: ctx.event?.original != null
    field: message
    ignore_missing: true
```
